### PR TITLE
Ignore rule extraneousDeps on specs

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,10 @@
 
 module.exports = {
   rules: {
-    'no-logger-log': require('./lib/rules/no-logger-log')
+    'no-logger-log': require('./lib/rules/no-logger-log'),
+    'import/no-extraneous-dependencies': [
+        "error",
+        { "devDependencies": [ "**/*.spec.js" ] }
+    ]
   }
 };


### PR DESCRIPTION
This will disable the eslint rule to warn on spec files about devDeps that should be put on deps