### PR TITLE
Fix for missing transaction declaration

### DIFF
--- a/lib/rules/transaction.js
+++ b/lib/rules/transaction.js
@@ -44,7 +44,7 @@ function findVariableDeclaration(node) {
     return node.id.name;
   }
 
-  return findVariableDeclaration(node.parent);
+  return node.parent ? findVariableDeclaration(node.parent) : null;
 }
 
 function blockIsTryCaught(block) {
@@ -69,6 +69,7 @@ module.exports = {
       missingTransactionEnding: 'missing {{ name }}.commit or {{ name }}.rollback',
       missingTransactionEndingAwait: 'missing await on {{ name }}.{{ property }}',
       missingTransactionTryCatch: 'transaction.start should be immediately followed by a try/catch block',
+      missingTransactionDeclaration: 'transaction variable should be declared in current scope',
     },
   },
   create: (context) => {
@@ -134,9 +135,18 @@ module.exports = {
      * @param  {Node} node
      */
     function onTransactionStarted(node) {
+      // get transaction object name from current variable declaration
+      const transactionVariableName = findVariableDeclaration(node.parent);
+      if (!transactionVariableName) {
+        return context.report({
+          node,
+          loc: node.loc,
+          messageId: 'missingTransactionDeclaration',
+        });
+      }
+
       scope.block.transaction = {
-        // get transaction object name from current variable declaration
-        name: findVariableDeclaration(node.parent),
+        name: transactionVariableName,
         node,
         func: scope,
       };

--- a/tests/lib/rules/transaction.js
+++ b/tests/lib/rules/transaction.js
@@ -260,5 +260,22 @@ ruleTester.run('transaction', rule, {
       `,
       errors: [{ messageId: 'missingTransactionEnding', type: 'CallExpression' }],
     },
+    // transaction variable defined outside of method scope
+    {
+      code: `
+        let trx;
+        async function test() {
+          trx = await transaction.start(knex);
+          try {
+            await trx.commit();
+            return true;
+          } catch (error) {
+            await trx.rollback();
+            return false;
+          }
+        }
+      `,
+      errors: [{ messageId: 'missingTransactionDeclaration', type: 'CallExpression' }],
+    },
   ],
 });


### PR DESCRIPTION
### Problem

The following code can exist in a unit test:
```
let trx;

afterEach(async () => {
  await trx.rollback();
});

it('tests transaction', async () => {
   trx = await transaction.start(Model);

  // other test things
});
```

The transaction variable is defined outside of the function scope. Such code should yield a warning from eslint, but currently it breaks eslint with an error: `TypeError: Cannot read property 'type' of null`.

### Solution
This PR fixes the behavior to show a warning and in such cases where transaction variable is defined outside of function exceptions like `eslint-disable-next-line` can be used.