### PR TITLE
[MW-188] fix: remove rule no-shadow

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,6 @@ module.exports = {
           enforceConst: true,
         }],
         'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 0 }],
-        'no-shadow': 'error',
         'no-undefined': 'error',
         'no-useless-call': 'error',
         'no-useless-catch': 'error',


### PR DESCRIPTION
Rule documentation : https://eslint.org/docs/rules/no-shadow

I consider this rule as harmful because it disallows such code
which I consider totally unambiguous:

```js
const task = tasks.find(task => task.id === fulfilledTaskId)
```

As a result, we end up writing code slightly less readable to
circumvent the rule:

```js
const task = tasks.find(({ id }) => id === fulfilledTaskId)
```

As always, eslint rules are a matter of preference.

See for instance [`8fb7583` (#128)](https://github.com/cubyn/service-storage-inventory-user-stock/pull/128/commits/8fb75839bd3bc9d4a4138054043c21eb5f7fbec4)