### PR TITLE
feat: Disable cubyn/logger-context

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,6 @@ module.exports = {
             'src/listeners/**/index.js',
           ],
           rules: {
-            'cubyn/logger-context': 'error',
             'cubyn/logger-error': 'error',
             'no-param-reassign': ['error', {
               props: true,


### PR DESCRIPTION
Since we can now use context manager hook it's ok not to have the context in logs.